### PR TITLE
Add LDR support for automatic brightness control

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This ESPHome component brings the fantastic [Clockwise](https://clockwise.page/)
 - **🎮 Retro Game Clockfaces**: Mario and Pac-Man themed clock displays
 - **🏠 Home Assistant Integration**: Full control via Home Assistant dashboard
 - **💡 Brightness Control**: Adjust display brightness (0-255) remotely
+- **🌅 Automatic Brightness**: Optional LDR sensor for automatic brightness adjustment
 - **🔄 Clockface Switching**: Change between clock styles on the fly
 - **⚡ Power Control**: Turn display on/off remotely
 - **🎯 Huidu HD-WF2 Support**: Optimized for HD-WF2 boards with automatic pin mapping
@@ -161,9 +162,37 @@ select:
 - Classic arcade font styling
 - Based on: [Original Pac-Man Clockface (cw-cf-0x05)](https://github.com/jnthas/cw-cf-0x05)
 
+### Automatic Brightness Control (Optional)
+
+The display can automatically adjust brightness based on ambient light using an LDR sensor:
+
+```yaml
+substitutions:
+  enable_ldr: "true"  # Set to "false" to disable
+  ldr_pin: GPIO4
+  ldr_update_interval: "2s"
+
+sensor:
+  - platform: adc
+    pin: ${ldr_pin}
+    name: "Ambient Light"
+    id: ambient_light
+    update_interval: ${ldr_update_interval}
+    attenuation: 12db
+    filters:
+      - sliding_window_moving_average:
+          window_size: 5
+      - calibrate_linear:
+          - 1.3 -> 0.0    # Dark voltage -> 0%
+          - 3.0 -> 100.0  # Bright voltage -> 100%
+    on_value:
+      # Maps 0-100% light to 20-255 brightness
+```
+
+**Calibration**: Measure your LDR voltage range in dark/bright conditions and adjust the `calibrate_linear` values accordingly. See the full example in `examples/clockwise.yaml`.
+
 ### Planned Features
 
-- **🌅 Automatic Brightness**: LDR sensor integration for automatic brightness adjustment
 - **🎮 More Themes**: Additional retro game clockfaces
 - **📊 Weather Display**: Weather information integration
 
@@ -260,5 +289,4 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 This project is maintained and tested with the hardware configurations listed above. New features and clockfaces are continuously being developed.
 
-**Current Status**: Stable for Mario and Pac-Man clockfaces
-**Next Release**: Automatic brightness control via LDR sensor
+**Current Status**: Stable for Mario and Pac-Man clockfaces with optional auto-brightness support

--- a/examples/clockwise.yaml
+++ b/examples/clockwise.yaml
@@ -10,8 +10,8 @@ substitutions:
   panel_height: "64"
   initial_brightness: "128"
   
-  # LDR Configuration (optional - comment out or set enable_ldr: "false" to disable)
-  enable_ldr: "true"  # Set to "false" to disable auto-brightness
+  # LDR Configuration (optional - set enable_ldr: "true" to enable)
+  enable_ldr: "false"  # Set to "true" to enable auto-brightness
   ldr_pin: GPIO4  # Light sensor pin (only used if enable_ldr is true)
   ldr_update_interval: "2s"  # How often to check light levels
 


### PR DESCRIPTION
```markdown
## Summary
Implements automatic brightness control using a Light Dependent Resistor (LDR) sensor. Closes #1 

## Changes
- Added LDR configuration substitutions (`enable_ldr`, `ldr_pin`, `ldr_update_interval`)
- Added ADC sensor for ambient light measurement
- Implemented automatic brightness adjustment (0-100% light → 20-255 brightness)
- Added smoothing via sliding window moving average
- Added calibration support via `calibrate_linear` filter
- Included commented debug sensor for voltage calibration
- Made feature optional via conditional automation

## Configuration Example
```yaml
substitutions:
  enable_ldr: "true"  # Set to "false" to disable auto-brightness
  ldr_pin: GPIO4
  ldr_update_interval: "2s"

Testing
✅ Tested with LDR on GPIO4
✅ Verified brightness adjusts from 20 (dark) to 255 (bright)
✅ Confirmed smooth transitions with moving average
✅ Calibrated for real-world voltage ranges (1.3V - 3.0V)
✅ Verified disable functionality works correctly
Calibration Guide
Users can calibrate for their specific LDR by:

Uncommenting the debug sensor to see raw voltage
Measuring voltage in dark and bright conditions
Updating calibrate_linear values accordingly
Commenting out debug sensor again
Breaking Changes
None - feature is completely optional and disabled by default for existing configurations.